### PR TITLE
Pass comments through

### DIFF
--- a/hgignore-to-gitignore.pl
+++ b/hgignore-to-gitignore.pl
@@ -28,7 +28,7 @@ while (<$hfh>) {
   $lineno++;
   my $line = $_;
   #print "line [$line]\n";
-  if ($line =~ /^\s*$/) {
+  if ($line =~ /^\s*$/ || $line =~ /^#/) {
     print $gfh "$_\n";
     next;
   }


### PR DESCRIPTION
Both .hgignore and .gitignore support comment lines beginning with "#"